### PR TITLE
添加Redmi 8(olive)的LOLZ内核构建

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@
  ### Redmi K60 / Poco F5 Pro (mondrian)
  **baalam**
 
+ ### Redmi 8(olive)
+ **LOLZ**
  共5个内核构建(主要是针对类原的构建) 
   
  ## 构建周期 
@@ -53,3 +55,6 @@
 
  ## Redmi K60 / Poco F5 Pro (mondrian)
  [Baalam](https://github.com/LowTension/android_kernel_xiaomi_sm8475)
+
+ ## Redmi 8(olive)
+[LOLZ](https://github.com/Jprimero15/lolz_kernel_redmi8)


### PR DESCRIPTION
Redmi 8(olive)的LOLZ内核(使用V22版本)
因为V23版本后的内核源码手动适配(导入)了KSU，导致本仓库编译时会报错而导致失败